### PR TITLE
DPI | 480 > 420 for OP3

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -61,7 +61,7 @@ ro.gps.agps_provider=1
 # Graphics
 debug.gralloc.enable_fb_ubwc=1
 ro.opengles.version=196610
-ro.sf.lcd_density=480
+ro.sf.lcd_density=420
 sdm.perf_hint_window=50
 persist.hwc.enable_vds=1
 


### PR DESCRIPTION
480 is a bit too large for the devices intended DPI by the display manufacturer, even in setup some of the animations clip over each other (For example the fingerprint initial setup the phone outline clips below the phones chin.)